### PR TITLE
fix: update NFS setup script to work for multiple gateways

### DIFF
--- a/modules/protocol_gateways/setup_nfs.sh
+++ b/modules/protocol_gateways/setup_nfs.sh
@@ -1,18 +1,73 @@
-# create interface group
-weka nfs interface-group add ${interface_group_name} NFS
+weka local ps
+
+function create_interface_group() {
+  if weka nfs interface-group | grep ${interface_group_name}; then
+    echo "$(date -u): interface group ${interface_group_name} already exists"
+    return
+  fi
+  echo "$(date -u): creating interface group"
+  weka nfs interface-group add ${interface_group_name} NFS
+  echo "$(date -u): interface group ${interface_group_name} created"
+}
+
+function create_client_group() {
+  if weka nfs client-group | grep ${client_group_name}; then
+    echo "$(date -u): client group ${client_group_name} already exists"
+    return
+  fi
+  echo "$(date -u): creating client group"
+  weka nfs client-group add ${client_group_name}
+  weka nfs rules add dns ${client_group_name} *
+  weka nfs permission add default ${client_group_name}
+  echo "$(date -u): client group ${client_group_name} created"
+}
+
+# make sure weka cluster is already up
+max_retries=60 # 60 * 30 = 30 minutes
+for (( i=0; i < max_retries; i++ )); do
+  if [ $(weka status | grep 'status: OK' | wc -l) -ge 1 ]; then
+    echo "$(date -u): weka cluster is up"
+    break
+  fi
+  echo "$(date -u): waiting for weka cluster to be up"
+  sleep 30
+done
+if (( i > max_retries )); then
+    echo "$(date -u): timeout: weka cluster is not up after $max_retries attempts."
+    exit 1
+fi
+
+# create interface group if not exists
+create_interface_group || true
+
+current_mngmnt_ip=$(weka local resources | grep 'Management IPs' | awk '{print $NF}')
 # get container id
-container_id=$(weka cluster container | grep frontend0 | grep ${gateways_name} | grep UP | awk '{print $1}')
+max_retries=12 # 12 * 10 = 2 minutes
+for ((i=0; i<max_retries; i++)); do
+  container_id=$(weka cluster container | grep frontend0 | grep ${gateways_name} | grep $current_mngmnt_ip | grep UP | awk '{print $1}')
+  if [ -n "$container_id" ]; then
+      echo "$(date -u): frontend0 container id: $container_id"
+      break
+  fi
+  echo "$(date -u): waiting for frontend0 container to be up"
+  sleep 10
+done
+
+if [ -z "$container_id" ]; then
+  echo "$(date -u): Failed to get the frontend0 container ID."
+  exit 1
+fi
+
 # get device to use
-port=$(ip -o -f inet addr show | grep -m 1 eth | awk '{print $2}')
+port=$(ip -o -f inet addr show | grep "$current_mngmnt_ip/"| awk '{print $2}')
 
 weka nfs interface-group port add ${interface_group_name} $container_id $port
 # show interface group
 weka nfs interface-group
 
-weka nfs client-group add ${client_group_name}
-weka nfs rules add dns ${client_group_name} *
-weka nfs permission add default ${client_group_name}
+# create client group if not exists and add rules / premissions
+create_client_group || true
+
 weka nfs client-group
 
-weka local ps
 echo "$(date -u): nfs setup complete"

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,17 +11,17 @@ data "azurerm_public_ip" "public_ips" {
 }
 
 output "backend_ips" {
-  value       = var.assign_public_ip ? data.azurerm_public_ip.public_ips.*.ip_address : local.first_nic_private_ips
+  value       = flatten(var.assign_public_ip ? data.azurerm_public_ip.public_ips.*.ip_address : local.first_nic_private_ips)
   description = "If 'assign_public_ip' is set to true, it will output backends public ips, otherwise private ips."
 }
 
 output "client_ips" {
-  value       = length(module.clients) > 0 ? module.clients.0.client-ips : null
+  value       = length(module.clients) > 0 ? flatten(module.clients.0.client-ips) : null
   description = "If 'assign_public_ip' is set to true, it will output clients public ips, otherwise private ips."
 }
 
 output "protocol_gateway_ips" {
-  value       = length(module.protocol_gateways) > 0 ? module.protocol_gateways.0.protocol_gateway_ips : null
+  value       = length(module.protocol_gateways) > 0 ? flatten(module.protocol_gateways.0.protocol_gateway_ips) : null
   description = "If 'assign_public_ip' is set to true, it will output protocol gateway public ips, otherwise private ips."
 }
 


### PR DESCRIPTION
```
module "weka_deployment" {
  ...
  clients_number           = 1
  protocol_gateways_number = 3
  protocol                 = "NFS"
}
```

```
weka@kk-test-protocol-gateway-0:~$ weka nfs interface-group
NAME     SUBNET MASK      GATEWAY          TYPE  STATUS  IPS  PORTS                                                                                                                                                                                                                                                                                 ALLOW MANAGE GIDS
weka-ig  255.255.255.255  255.255.255.255  NFS   OK           [     host_uid: 6761a08f-f824-c8b9-8525-d0ea0a55ee5f,host_id: HostId<18>,port: eth0,status: OK,,host_uid: 9e52f930-8066-d863-8255-d90194ea9137,host_id: HostId<19>,port: eth0,status: OK,,host_uid: 4101088a-548a-c7bc-56fe-f4e41a026d30,host_id: HostId<20>,port: eth0,status: OK ]  True
```