### PR TITLE
fix: use backend placement_group for clients for empty client_placement_group_id

### DIFF
--- a/vms.tf
+++ b/vms.tf
@@ -26,7 +26,7 @@ module "clients" {
   instance_type                = var.client_instance_type
   backend_ips                  = local.first_nic_private_ips
   ssh_public_key               = var.ssh_public_key == null ? tls_private_key.ssh_key[0].public_key_openssh : var.ssh_public_key
-  ppg_id                       = var.client_placement_group_id != "" ? var.client_placement_group_id : azurerm_proximity_placement_group.ppg[0].id
+  ppg_id                       = var.client_placement_group_id == "" ? local.placement_group_id : var.client_placement_group_id
   assign_public_ip             = var.assign_public_ip
   vnet_rg_name                 = local.vnet_rg_name
   depends_on                   = [azurerm_linux_virtual_machine.clusterizing, module.network]
@@ -114,6 +114,8 @@ locals {
     local.install_weka_script, local.deploy_script
   ]
   custom_data = join("\n", local.custom_data_parts)
+
+  placement_group_id = var.placement_group_id != "" ? var.placement_group_id : azurerm_proximity_placement_group.ppg[0].id
 }
 
 resource "azurerm_proximity_placement_group" "ppg" {


### PR DESCRIPTION
Fix error which appears if `placement_group_id` is provided and `client_placement_group_id` is not :
```
[24 Nov 2023 13:20:53 +0100] failed to apply TF in tf-provision-azure-e_QmUrzmUACNGB286W: exit status 1

Error: Invalid index

  on .terraform/modules/weka_cluster/vms.tf line 29, in module "clients":
  29:   ppg_id                       = var.client_placement_group_id != "" ? var.client_placement_group_id : azurerm_proximity_placement_group.ppg[0].id
    ├────────────────
    │ azurerm_proximity_placement_group.ppg is empty tuple

The given key does not identify an element in this collection value: the
collection has no elements.
```